### PR TITLE
Potential fix for code scanning alert no. 50: Type confusion through parameter tampering

### DIFF
--- a/major-project-backend/middleware/adminAuth.js
+++ b/major-project-backend/middleware/adminAuth.js
@@ -12,22 +12,17 @@ const adminAuth = async (req, res, next) => {
             token = req.query.token;
         }
 
-        // Format token - remove 'Bearer ' if present
-        if (token && token.startsWith('Bearer ')) {
-            token = token.slice(7);
-        }
-
+        // Ensure token is a string before using string methods
         if (!token || typeof token !== 'string') {
             console.log('Invalid token type');
             return res.status(400).json({ 
                 error: 'Invalid token',
                 details: 'Token must be a string'
             });
-            console.log('No token provided');
-            return res.status(401).json({ 
-                error: 'Authentication required',
-                details: 'No authentication token found in request'
-            });
+        }
+        // Format token - remove 'Bearer ' if present
+        if (token.startsWith('Bearer ')) {
+            token = token.slice(7);
         }
 
         // Verify token


### PR DESCRIPTION
Potential fix for [https://github.com/parui4622/NeuroVision/security/code-scanning/50](https://github.com/parui4622/NeuroVision/security/code-scanning/50)

To fix the problem, we must ensure that any user-controlled input (such as `req.query.token`) is of type `string` before calling string methods like `startsWith` or `slice`. The best way to do this is to check the type of `token` immediately after it is assigned, and before any string methods are called. If `token` is not a string, the function should return an error response. This change should be made in the `adminAuth` middleware in `major-project-backend/middleware/adminAuth.js`, specifically after assigning `token` from headers or query parameters, and before any string operations are performed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
