### PR TITLE
Potential fix for code scanning alert no. 51: Missing rate limiting

### DIFF
--- a/major-project-backend/routes/auth.js
+++ b/major-project-backend/routes/auth.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const router = express.Router();
 const { 
     signup, 
@@ -9,7 +10,14 @@ const {
     resendOTP 
 } = require('../controllers/authController');
 
-router.post('/signup', signup);
+// Rate limiter for signup route: max 5 requests per hour per IP
+const signupLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000, // 1 hour
+    max: 5,
+    message: 'Too many signup attempts from this IP, please try again after an hour'
+});
+
+router.post('/signup', signupLimiter, signup);
 router.post('/login', login);
 router.post('/logout', logout);
 router.get('/validate-session', validateSession);


### PR DESCRIPTION
Potential fix for [https://github.com/parui4622/NeuroVision/security/code-scanning/51](https://github.com/parui4622/NeuroVision/security/code-scanning/51)

To fix the missing rate limiting on the `/signup` route, we should add a rate limiting middleware to this route. The best way is to use the well-known `express-rate-limit` package, which is designed for this purpose. We will import `express-rate-limit`, define a rate limiter (e.g., allowing a reasonable number of signup attempts per IP per time window), and apply it specifically to the `/signup` route. This minimizes the risk of DoS and brute-force attacks without affecting other routes.

**Steps:**
- Import `express-rate-limit` at the top of the file.
- Define a rate limiter instance with appropriate settings (e.g., 5 requests per hour per IP for signup).
- Apply the rate limiter as middleware to the `/signup` route.
- No changes to the existing functionality of the signup handler.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
