### PR TITLE
Potential fix for code scanning alert no. 47: Database query built from user-controlled sources

### DIFF
--- a/major-project-backend/controllers/authController.js
+++ b/major-project-backend/controllers/authController.js
@@ -209,6 +209,10 @@ exports.resendOTP = async (req, res) => {
     try {
         const { userId } = req.body;
         
+        if (typeof userId !== "string") {
+            return res.status(400).json({ error: 'Invalid userId' });
+        }
+        
         const user = await User.findById(userId);
         if (!user) {
             return res.status(400).json({ error: 'User not found' });


### PR DESCRIPTION
Potential fix for [https://github.com/parui4622/NeuroVision/security/code-scanning/47](https://github.com/parui4622/NeuroVision/security/code-scanning/47)

To fix the problem, we should ensure that the `userId` value from `req.body` is a literal value (string or valid ObjectId) and not a query object. The best way to do this is to check the type of `userId` before passing it to `User.findById`. If it is not a string, we should reject the request with a 400 error. This change should be made in the `resendOTP` handler, specifically before calling `User.findById(userId)` on line 212. No new imports are needed, as this is a simple type check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
