### PR TITLE
Potential fix for code scanning alert no. 22: Missing rate limiting

### DIFF
--- a/major-project-backend/routes/auth.js
+++ b/major-project-backend/routes/auth.js
@@ -17,11 +17,18 @@ const signupLimiter = rateLimit({
     message: 'Too many signup attempts from this IP, please try again after an hour'
 });
 
+// Rate limiter for verify-email route: max 5 requests per hour per IP
+const verifyEmailLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000, // 1 hour
+    max: 5,
+    message: 'Too many verification attempts from this IP, please try again after an hour'
+});
+
 router.post('/signup', signupLimiter, signup);
 router.post('/login', login);
 router.post('/logout', logout);
 router.get('/validate-session', validateSession);
-router.post('/verify-email', verifyEmail);
+router.post('/verify-email', verifyEmailLimiter, verifyEmail);
 router.post('/resend-otp', resendOTP);
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/parui4622/NeuroVision/security/code-scanning/22](https://github.com/parui4622/NeuroVision/security/code-scanning/22)

To fix the problem, we should add a rate limiter to the `/verify-email` route, similar to what is done for `/signup`. The rate limiter should be configured to allow a reasonable number of verification attempts per IP within a certain time window to prevent abuse (e.g., brute-forcing verification codes or flooding the endpoint). The best way is to define a new rate limiter instance (e.g., `verifyEmailLimiter`) with appropriate settings (such as 5 attempts per hour per IP), and apply it as middleware to the `/verify-email` route. This change should be made in `major-project-backend/routes/auth.js`, by adding the limiter definition and updating the route to use it.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
